### PR TITLE
Add integration tests against geth and aleth

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
   lint:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.7
         environment:
           TOXENV: lint
   py36-core:
@@ -66,6 +66,37 @@ jobs:
       - image: pypy
         environment:
           TOXENV: pypy3-core
+  # Integration tests use docker to spin up different backends (geth, aleth etc.). Running
+  # docker is simpler when the host isn't a docker container itself
+  py36-integration-geth:
+    <<: *common
+    machine:
+        image: ubuntu-1604:201903-01
+    environment:
+      TOXENV: py36-integration-geth
+      PYENV_VERSION: 3.6.5
+  py36-integration-aleth:
+    <<: *common
+    machine:
+        image: ubuntu-1604:201903-01
+    environment:
+      TOXENV: py36-integration-aleth
+      PYENV_VERSION: 3.6.5
+  py37-integration-geth:
+    <<: *common
+    machine:
+        image: ubuntu-1604:201903-01
+    environment:
+      TOXENV: py37-integration-geth
+      PYENV_VERSION: 3.7.0
+  py37-integration-aleth:
+    <<: *common
+    machine:
+        image: ubuntu-1604:201903-01
+    environment:
+      TOXENV: py37-integration-aleth
+      PYENV_VERSION: 3.7.0
+
 workflows:
   version: 2
   test:
@@ -75,3 +106,7 @@ workflows:
       - py36-core
       - py37-core
       - pypy3-core
+      - py36-integration-geth
+      - py36-integration-aleth
+      - py37-integration-geth
+      - py37-integration-aleth

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ chains
 
 # tox/pytest cache
 .cache
+.pytest_cache
 
 # Test output logs
 logs

--- a/dopple/tools/runner.py
+++ b/dopple/tools/runner.py
@@ -1,0 +1,88 @@
+import logging
+import pathlib
+import socket
+import tempfile
+import time
+from typing import AsyncIterator, Callable
+
+import trio
+
+try:
+    from contextlib import asynccontextmanager
+except ImportError:
+    # We use this as a fallback to support Python 3.6
+    from async_generator import asynccontextmanager  # type: ignore
+
+
+DOPPLE_FILE = pathlib.Path(__file__).parent.parent / "dopple.py"
+
+
+@asynccontextmanager
+async def run_eth_client_in_docker(
+    generate_cmd_fn: Callable[[pathlib.Path], str],
+    generate_ipc_path_fn: Callable[[pathlib.Path], pathlib.Path],
+) -> AsyncIterator[pathlib.Path]:
+    """
+    Create an ``asynccontextmanager`` that runs an Ethereum client within docker
+    under the user account of the host user. A temporary directory is created on
+    the host system and should be mapped into the docker container to allow the
+    client to share IPC files with the host system. Yield the IPC path of the client.
+
+    :param generate_cmd_fn: A function taking the ``Path`` of the temporary directory
+    and generating the relevant part of the docker command to launch the client with
+    the mapped directory.
+
+    :param generate_ipc_path_fn: A function taking the ``Path`` of the temprorary directory
+    and generating the ``Path`` of the IPC file that dopple can connect to.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        temp_dir = pathlib.Path(tmpdir)
+
+        start_cmd = (
+            f"docker run --rm --name {temp_dir.name} "
+            f"--user $(id -u):$(id -g) {generate_cmd_fn(temp_dir)}"
+        )
+        stop_cmd = f"docker stop {temp_dir.name}"
+
+        ipc_path = generate_ipc_path_fn(temp_dir)
+        logging.debug(f"Starting client, ipc path: {ipc_path}")
+        async with await trio.open_process(start_cmd, shell=True):
+            logging.debug("Started client, waiting for IPC socket to be ready")
+            wait_for_socket(ipc_path)
+            logging.debug("IPC ready")
+            yield ipc_path
+            logging.debug("Killing client")
+            await trio.run_process(stop_cmd, shell=True)
+            logging.debug("Killed client")
+
+
+@asynccontextmanager
+async def run_dopple_as_script(ipc_path: pathlib.Path) -> AsyncIterator[None]:
+    """
+    Run geth, then run dopple as a script file to connect to it.
+    """
+    logging.debug("Starting dopple")
+    async with await trio.open_process([DOPPLE_FILE, ipc_path]) as proc:
+        logging.debug("Started dopple")
+        await trio.sleep(0.5)
+        yield
+        logging.debug("Terminating dopple")
+        proc.terminate()
+        await proc.wait()
+        logging.debug("Terminated dopple")
+
+
+def wait_for_socket(ipc_path: pathlib.Path, timeout: int = 10) -> None:
+    """
+    Wait for the ``ipc_path`` to be ready.
+    """
+    start = time.monotonic()
+    while time.monotonic() < start + timeout:
+        try:
+            sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            sock.connect(str(ipc_path))
+            sock.settimeout(timeout)
+        except (FileNotFoundError, socket.error):
+            time.sleep(0.01)
+        else:
+            break

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,11 @@ from setuptools import (
 extras_require = {
     'test': [
         "pytest>=5.1.3,<6",
+        "pytest-trio==0.5.2",
         "pytest-xdist==1.18.1",
+        "requests==2.22.0",
         "tox>=2.9.1,<3",
+        "trio==0.13.0",
     ],
     'lint': [
         "black==19.3b",

--- a/tests/integration/test_dopple_as_script.py
+++ b/tests/integration/test_dopple_as_script.py
@@ -1,0 +1,61 @@
+from dopple.tools.runner import run_dopple_as_script, run_eth_client_in_docker
+import pytest
+import requests
+
+# The following tests invoke dopple as a pure file (as opposed to a package installed through pip)
+# and test it's functionality against different clients.
+
+
+def geth_cmd(tmpdir):
+    return (
+        f"-v {tmpdir}:/tmp/.ethereum ethereum/client-go:v1.9.6 --datadir /tmp/.ethereum"
+    )
+
+
+def generate_geth_ipc_path(tmpdir):
+    return tmpdir / "geth.ipc"
+
+
+def aleth_cmd(tmpdir):
+    return f"-v {tmpdir}:/.ethereum ethereum/aleth:1.6.0"
+
+
+GETH_LAUNCH_FNS = geth_cmd, generate_geth_ipc_path
+# Not a bug, aleth names its IPC file `geth.ipc`
+ALETH_LAUNCH_FNS = aleth_cmd, generate_geth_ipc_path
+
+# Test cases *must* follow this order to label each test case to the correct client
+TEST_IDS = ("geth", "aleth")
+
+
+@pytest.mark.parametrize(
+    "client_config", (GETH_LAUNCH_FNS, ALETH_LAUNCH_FNS), ids=TEST_IDS
+)
+@pytest.mark.trio
+async def test_run_and_get_info(client_config):
+    async with run_eth_client_in_docker(*client_config) as ipc_path:
+        async with run_dopple_as_script(ipc_path):
+            ret = requests.get("http://127.0.0.1:8545")
+            assert str(ipc_path) in ret.text
+            assert "connected: True" in ret.text
+
+
+@pytest.mark.parametrize(
+    "client_config", (GETH_LAUNCH_FNS, ALETH_LAUNCH_FNS), ids=TEST_IDS
+)
+@pytest.mark.trio
+async def test_can_request_data(client_config):
+    data = {
+        "jsonrpc": "2.0",
+        "method": "eth_getBlockByNumber",
+        "params": ["0x0", True],
+        "id": 1,
+    }
+    async with run_eth_client_in_docker(*client_config) as ipc_path:
+        async with run_dopple_as_script(ipc_path):
+            ret = requests.post("http://127.0.0.1:8545", json=data)
+            # Assert the genesis block hash is in the result
+            assert (
+                "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3"
+                in ret.text
+            )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist=
     py{36,37,py3}-core
+    py{36,37}-integration-{geth, aleth}
     lint
     docs
 
@@ -22,6 +23,8 @@ ignore=
 usedevelop=True
 commands=
     core: pytest {posargs:tests/core}
+    integration-geth: pytest {posargs:tests/integration -k 'geth'}
+    integration-aleth: pytest {posargs:tests/integration -k 'aleth'}
     docs: make build-docs
 basepython =
     docs: python


### PR DESCRIPTION
## What was wrong?

We currently do not have any tests. Before we continue refactoring and improving parts of the code base, we need to have some basic tests in place to ensure we do not break existing code.

## How was it fixed?

These tests prove that:

- Dopple can be used as a pure script file (as opposed to requiring a installation through `pip`).
  - This is how dopple is currently used within Aleth and I wanted to protect that functionality until we do a deliberate decision against it and maybe come up with alternatives such as binary distribution
- Requests can be served against geth
- Requests can be served against aleth

Notice that Trinity is not yet supported as dopple assumes the sockets to separate JSON payload by line breaks (something that I want to change on the dopple side)

### Further notes

I  think it would also be good to have tests that prove that dopple can in fact also be installed through `pip` and launched as a global command. But I didn't want to go as far in this PR.