### PR TITLE
Expose some useful primitives

### DIFF
--- a/dopple/__init__.py
+++ b/dopple/__init__.py
@@ -1,1 +1,8 @@
-from .dopple import main  # noqa: F401
+from .dopple import (  # noqa: F401
+    DEFAULT_BACKEND_PATH,
+    DEFAULT_PROXY_URL,
+    Proxy,
+    main,
+    run,
+    run_daemon,
+)

--- a/newsfragments/10.feature.rst
+++ b/newsfragments/10.feature.rst
@@ -1,0 +1,2 @@
+Expose some basic functions and constants.
+This change is needed to make dopple usable as a library.


### PR DESCRIPTION
## What was wrong?

We need to expose some basic functions and constants to make it possible to use dopple as a library in Trinity.

## How was it fixed?

Just importing some things in `__init__.py`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/dopple/blob/master/newsfragments/README.md)

[//]: # (See: https://dopple.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/dopple/blob/master/newsfragments/README.md)
